### PR TITLE
Fixes not rendering of ReadNext component

### DIFF
--- a/components/ReadNext/index.jsx
+++ b/components/ReadNext/index.jsx
@@ -7,7 +7,8 @@ import './style.css'
 
 class ReadNext extends React.Component {
     render() {
-        const {pages, post} = this.props
+        const {post} = this.props
+        const {pages} = this.props.route
         const {readNext} = post
 
         let nextPost


### PR DESCRIPTION
The component didn't render because pages were undefined.
I found that they are stored inside the route object.
This fixed it for me.