### PR TITLE
Updates to remove React warnings

### DIFF
--- a/components/SitePage/index.jsx
+++ b/components/SitePage/index.jsx
@@ -33,8 +33,7 @@ class SitePage extends React.Component {
 }
 
 SitePage.propTypes = {
-    post: React.PropTypes.object.isRequired,
-    pages: React.PropTypes.array,
+    route: React.PropTypes.object.isRequired,
 }
 
 export default SitePage

--- a/components/SitePost/index.jsx
+++ b/components/SitePost/index.jsx
@@ -46,8 +46,7 @@ class SitePost extends React.Component {
 }
 
 SitePost.propTypes = {
-    post: React.PropTypes.object.isRequired,
-    pages: React.PropTypes.array,
+    route: React.PropTypes.object.isRequired
 }
 
 export default SitePost

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -23,7 +23,7 @@ class SiteIndex extends React.Component {
                 const category = access(page, 'data.category')
 
                 pageLinks.push(
-                    <div className='blog-post'>
+                    <div className='blog-post' key={ title }>
                       <time dateTime={ moment(datePublished).format('MMMM D, YYYY') }>
                         { moment(datePublished).format('MMMM YYYY') }
                       </time>


### PR DESCRIPTION
Here are fixes that should close #25.

Added a key to pageLinks within SiteIndex to remove warning that key is required when creating a list of elements.

Update required prop for SitePost by changing required prop from `post` to `route` and removing propType for `pages`.  These are objects on `route` prop and not passed in individually.

Let me know if you have questions or would like changes.

Axel