### PR TITLE
prefixLink unnecessary for profilePic Closes #32

### DIFF
--- a/components/SiteSidebar/index.jsx
+++ b/components/SiteSidebar/index.jsx
@@ -15,7 +15,7 @@ class SiteSidebar extends React.Component {
         let header = (
         <header>
           <Link style={ {    textDecoration: 'none',    borderBottom: 'none',    outline: 'none'} } to={ prefixLink('/') }>
-          <img src={prefixLink(profilePic)} width='75' height='75' />
+          <img src={profilePic} width='75' height='75' />
           </Link>
           { isHome ? (
             <h1><Link style={ {    textDecoration: 'none',    borderBottom: 'none',    color: 'inherit'} } to={ prefixLink('/') }> { config.siteAuthor } </Link></h1>


### PR DESCRIPTION
Addresses [issue: 32](https://github.com/wpioneer/gatsby-starter-lumen/issues/32)

I created the PR from within Github. It added a newline to the file.